### PR TITLE
Correct binary paths used on Windows + MinGW

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://install.python-poetry.org/.
 Poetry provides a custom installer that will install `poetry` isolated
 from the rest of your system.
 
-### osx / linux / bashonwindows install instructions
+### osx / linux / bashonwindows / Windows+MinGW install instructions
 ```bash
 curl -sSL https://install.python-poetry.org | python -
 ```

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -22,6 +22,7 @@ import shutil
 import site
 import subprocess
 import sys
+import sysconfig
 import tempfile
 
 from contextlib import closing
@@ -36,6 +37,7 @@ from urllib.request import urlopen
 
 SHELL = os.getenv("SHELL", "")
 WINDOWS = sys.platform.startswith("win") or (sys.platform == "cli" and os.name == "nt")
+MINGW = sysconfig.get_platform().startswith("mingw")
 MACOS = sys.platform == "darwin"
 
 FOREGROUND_COLORS = {
@@ -158,7 +160,7 @@ def bin_dir(version: Optional[str] = None) -> Path:
 
     user_base = site.getuserbase()
 
-    if WINDOWS:
+    if WINDOWS and not MINGW:
         bin_dir = os.path.join(user_base, "Scripts")
     else:
         bin_dir = os.path.join(user_base, "bin")
@@ -273,14 +275,19 @@ class PoetryInstallationError(RuntimeError):
 class VirtualEnvironment:
     def __init__(self, path: Path) -> None:
         self._path = path
+        self._bin_path = self._path.joinpath("Scripts" if WINDOWS and not MINGW else "bin")
         # str is required for compatibility with subprocess run on CPython <= 3.7 on Windows
         self._python = str(
-            self._path.joinpath("Scripts/python.exe" if WINDOWS else "bin/python")
+            self._path.joinpath(self._bin_path, "python.exe" if WINDOWS else "python")
         )
 
     @property
     def path(self):
         return self._path
+
+    @property
+    def bin_path(self):
+        return self._bin_path
 
     @classmethod
     def make(cls, target: Path) -> "VirtualEnvironment":
@@ -602,12 +609,8 @@ class Installer:
         self._install_comment(version, "Creating script")
         self._bin_dir.mkdir(parents=True, exist_ok=True)
 
-        script = "poetry"
-        script_bin = "bin"
-        if WINDOWS:
-            script = "poetry.exe"
-            script_bin = "Scripts"
-        target_script = env.path.joinpath(script_bin, script)
+        script = "poetry.exe" if WINDOWS else "poetry"
+        target_script = env.bin_path.joinpath(script)
 
         if self._bin_dir.joinpath(script).exists():
             self._bin_dir.joinpath(script).unlink()

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -275,7 +275,9 @@ class PoetryInstallationError(RuntimeError):
 class VirtualEnvironment:
     def __init__(self, path: Path) -> None:
         self._path = path
-        self._bin_path = self._path.joinpath("Scripts" if WINDOWS and not MINGW else "bin")
+        self._bin_path = self._path.joinpath(
+            "Scripts" if WINDOWS and not MINGW else "bin"
+        )
         # str is required for compatibility with subprocess run on CPython <= 3.7 on Windows
         self._python = str(
             self._path.joinpath(self._bin_path, "python.exe" if WINDOWS else "python")


### PR DESCRIPTION
`python[.exe]`, when installed via (msys) MinGW on Windows, can be found under a path structure similar to that you might find on *nix systems.

The `install-python.py` script was not taking this into consideration, causing installation failure under Windows + MinGW.

A similar fault in `poetry` itself was resolved with python-poetry/poetry#3713.

----

PR originally filed as python-poetry/poetry#4467, migrated here as requested; and updated.