### PR TITLE
Deprecate Python 3.6

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, macOS, Windows]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         args:
           - ""
           - "--preview"

--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ You can also install Poetry for a `git` repository by using the `--git` option:
 python install-poetry.py --git https://github.com/python-poetry/poetry.git@master
 ````
 
-**Note**: Note that the installer does not support Python < 3.6.
+**Note**: Note that the installer does not support Python < 3.7.


### PR DESCRIPTION
Resolves: https://github.com/python-poetry/poetry/issues/4997


See also: https://github.com/python-poetry/poetry/pull/5055, https://github.com/python-poetry/poetry-core/pull/263