### PR TITLE
Drop  from pip arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -371,3 +371,4 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+.idea

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -346,7 +346,7 @@ class VirtualEnvironment:
         return self.run(self._python, *args, **kwargs)
 
     def pip(self, *args, **kwargs) -> subprocess.CompletedProcess:
-        return self.python("-m", "pip", "--isolated", *args, **kwargs)
+        return self.python("-m", "pip", *args, **kwargs)
 
 
 class Cursor:


### PR DESCRIPTION
Resolves: python-poetry/poetry#5219

As per suggestion in issue comments, dropped `--isolated` argument on `pip` call.