### PR TITLE
fix: resolve env path in case windows redirects installation path

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -297,7 +297,15 @@ class VirtualEnvironment:
             import venv
 
             builder = venv.EnvBuilder(clear=True, with_pip=True, symlinks=False)
-            builder.ensure_directories(target)
+            context = builder.ensure_directories(target)
+
+            if (
+                WINDOWS
+                and hasattr(context, "env_exec_cmd")
+                and context.env_exe != context.env_exec_cmd
+            ):
+                target = target.resolve()
+
             builder.create(target)
         except ImportError:
             # fallback to using virtualenv package if venv is not available, eg: ubuntu


### PR DESCRIPTION
Applications installed from the Microsoft Store are not allowed to write directly into %Appdata%, instead any attempt to do this is redirected to a sandbox folder located at C:\Users\username\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0.

Fortunately when one try to access this place during runtime, the Path object is a symlink that can be resolved and than be passed to the subprocess call that creates the venv.

Relates-To: https://github.com/python-poetry/poetry/pull/5931, https://github.com/python-poetry/poetry/issues/5331