### PR TITLE
Delete leftover poetry script on windows

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -571,7 +571,7 @@ class Installer:
             self._write("Removing {}".format(colorize("info", "Poetry")))
 
         shutil.rmtree(str(self._data_dir))
-        for script in ["poetry", "poetry.bat"]:
+        for script in ["poetry", "poetry.bat", "poetry.exe"]:
             if self._bin_dir.joinpath(script).exists():
                 self._bin_dir.joinpath(script).unlink()
 


### PR DESCRIPTION
It seems that the file name of newer poetry script on Windows is `poetry.exe` but not `poetry.bat` after I installed poetry v1.1.14. which is located at `C:\Users\{UserName}\AppData\Roaming\Python\Scripts\` in my environment.