### PR TITLE
Bump `flake8` and additional dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-bugbear==22.4.25
+          - flake8-bugbear==22.7.1
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1


### PR DESCRIPTION
Supersedes https://github.com/python-poetry/install.python-poetry.org/pull/25.

`flake8-bugbear` update is required to make the upgrade to `flake8 >= 5.0.0`, per [CI](https://results.pre-commit.ci/run/github/427490957/1659396134.-OKQo_fxQ-SJmyCDk84pmA).