### PR TITLE
refactor: update path handling and comments

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -25,12 +25,12 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, macOS, Windows]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
         args:
           - ""
           - "--preview"
           - "--git https://github.com/python-poetry/poetry.git"
-          - "--version 1.1.14"
+          - "--version 1.1.15"
         include:
           - os: Ubuntu
             image: ubuntu-latest

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -91,7 +91,7 @@ jobs:
     strategy:
       matrix:
         tag:
-          - impish
+          - focal
           - jammy
     defaults:
       run:


### PR DESCRIPTION
This is part of a major overhaul of the installer I hope to complete in
a relatively short time. This first pass makes sure we use consistent
directories on all platforms by preferring the documented paths to a
possibly unexpected `site.getuserbase()` (which results in a Library
path on macOS Framework builds, like Homebrew and OS-provided Pythons).

Path handling as a whole is updated to take advantage of `pathlib` and
DRY up some tedious code. It also starts the first stage of increasing
use of classes and careful thought as to the visibility of class-level
attributes in this script -- I hope to end up with a DSL-like end result
that is as informative as possible to the reader of this script.
