### PR TITLE
Consistently use `install.python-poetry.org` in the README

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -15,7 +15,7 @@ on:
       - '**'
 
 concurrency:
-  group: installer-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -39,6 +39,7 @@ jobs:
             image: windows-2022
           - os: macOS
             image: macos-12
+      fail-fast: false
     defaults:
       run:
         shell: bash

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Python Poetry Installer
+
 This repository contains Poetry's official installation script, installer source and
 related hosting configuration.
 
@@ -11,16 +12,21 @@ Poetry provides a custom installer that will install `poetry` isolated
 from the rest of your system.
 
 ### osx / linux / bashonwindows / Windows+MinGW install instructions
+
 ```bash
-curl -sSL https://install.python-poetry.org | python -
-```
-### windows powershell install instructions
-```powershell
-(Invoke-WebRequest -Uri https://install.python-poetry.org -UseBasicParsing).Content | python -
+curl -sSL https://install.python-poetry.org | python3 -
 ```
 
+### windows powershell install instructions
+
+```powershell
+(Invoke-WebRequest -Uri https://install.python-poetry.org -UseBasicParsing).Content | py -
+```
+
+> If you have installed Python through the Microsoft Store, replace `py` with `python` in the command above.
+
 **Warning**: The previous `get-poetry.py` installer is now deprecated, if you are currently using it
-you should migrate to the new, supported, `install-poetry.py` installer.
+you should migrate to the new, supported, `install.python-poetry.org` installer.
 
 The installer installs the `poetry` tool to Poetry's `bin` directory. This location depends on your system:
 
@@ -41,44 +47,43 @@ poetry --version
 If you see something like `Poetry (version 1.2.0)` then you are ready to use Poetry.
 If you decide Poetry isn't your thing, you can completely remove it from your system
 by running the installer again with the `--uninstall` option or by setting
-the `POETRY_UNINSTALL` environment variable before executing the installer.
+the `POETRY_UNINSTALL` environment variable before executing the installer:
 
 ```bash
-python install-poetry.py --uninstall
-POETRY_UNINSTALL=1 python install-poetry.py
+curl -sSL https://install.python-poetry.org | python3 - --uninstall
+curl -sSL https://install.python-poetry.org | POETRY_UNINSTALL=1 python3 -
 ```
 
 By default, Poetry is installed into the user's platform-specific home directory.
 If you wish to change this, you may define the `POETRY_HOME` environment variable:
 
 ```bash
-POETRY_HOME=/etc/poetry python install-poetry.py
+curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python3 -
 ```
 
-If you want to install prerelease versions, you can do so by passing `--preview` option to `install-poetry.py`
-or by using the `POETRY_PREVIEW` environment variable:
+If you want to install prerelease versions, you can do so by passing `--preview` option or by using the `POETRY_PREVIEW`
+environment variable:
 
 ```bash
-python install-poetry.py --preview
-POETRY_PREVIEW=1 python install-poetry.py
+curl -sSL https://install.python-poetry.org | python3 - --preview
+curl -sSL https://install.python-poetry.org | POETRY_PREVIEW=1 python3 -
 ```
 
 Similarly, if you want to install a specific version, you can use `--version` option or the `POETRY_VERSION`
 environment variable:
 
 ```bash
-python install-poetry.py --version 1.2.0
-POETRY_VERSION=1.2.0 python install-poetry.py
+curl -sSL https://install.python-poetry.org | python3 - --version 1.2.0
+curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.2.0 python3 -
 ```
 
 You can also install Poetry for a `git` repository by using the `--git` option:
 
 ```bash
-python install-poetry.py --git https://github.com/python-poetry/poetry.git@master
+curl -sSL https://install.python-poetry.org | python3 - --git https://github.com/python-poetry/poetry.git@master
 ````
 
-**Note**: Note that the installer does not support Python < 3.6.
-
+> **Note**: The installer does not support Python < 3.6.
 
 ## Known Issues
 
@@ -91,6 +96,7 @@ details issues we are presently aware of, and potential workarounds.
 > **Note:** This can also affect WSL users on Windows.
 
 #### Installation Layout
+
 If you encounter an error similar to the following, this might be due to
 [pypa/virtualenv#2350](https://github.com/pypa/virtualenv/issues/2350).
 
@@ -101,7 +107,7 @@ FileNotFoundError: [Errno 2] No such file or directory: '/root/.local/share/pypo
 You can work around this issue by setting the `DEB_PYTHON_INSTALL_LAYOUT` environment
 variable to `deb` in order to emulate previously working behaviour.
 
-```sh
+```bash
 export DEB_PYTHON_INSTALL_LAYOUT=deb
 ```
 
@@ -120,7 +126,7 @@ See also [pypa/get-pip#124](https://github.com/pypa/get-pip/issues/124).
 The known workaround for this issue is to reinstall the `distutils` package provided by
 the distribution.
 
-```sh
+```bash
 apt-get install --reinstall python3-distutils
 ```
 


### PR DESCRIPTION
Consistently use `install.python-poetry.org` in the README, instead of mixing it up with `install-poetry.py`, and use `python3`, similarly to Poetry's documentation.

Also setting `fail-fast` to `false` on the CI matrix, as a bonus.