### PR TITLE
Change -dev to full Python 3.11 version

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, macOS, Windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         args:
           - ""
           - "--preview"


### PR DESCRIPTION
As in the title, this PR removes the -dev part from Python 3.11 version in CI. 