### PR TITLE
Change min required Python to 3.7

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -838,9 +838,9 @@ class Installer:
 
 
 def main():
-    if sys.version_info < (3, 6):
+    if sys.version_info < (3, 7):
         sys.stdout.write(
-            colorize("error", "Poetry installer requires Python 3.6 or newer to run!")
+            colorize("error", "Poetry installer requires Python 3.7 or newer to run!")
         )
         # return error code
         return 1


### PR DESCRIPTION
install-poetry.py currently requires Python 3.6 or newer to run, which contradicts [Poetry documentation](https://python-poetry.org/docs/#system-requirements), [Poetry pyproject.toml](https://github.com/python-poetry/poetry/blob/1.2.2/pyproject.toml#L45), and [PyPI metadata](https://pypi.org/project/poetry/1.2.2/). When trying to run the installer using Python 3.6 pip attempts to install the latest Poetry version on PyPI, but fails to find it since it doesn't support Python 3.6. Instead, the installer should detect when being run under 3.6 and immediately abort with an explicit error.