### PR TITLE
Solve install issue for unix

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -306,7 +306,11 @@ class VirtualEnvironment:
             import ensurepip  # noqa: F401
             import venv
 
-            builder = venv.EnvBuilder(clear=True, with_pip=True, symlinks=False)
+            if os.name == 'nt':
+                use_symlinks = False
+            else:
+                use_symlinks = True
+            builder = venv.EnvBuilder(clear=True, with_pip=True, symlinks=use_symlinks)
             context = builder.ensure_directories(target)
 
             if (

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -306,7 +306,7 @@ class VirtualEnvironment:
             import ensurepip  # noqa: F401
             import venv
 
-            if os.name == 'nt':
+            if os.name == "nt":
                 use_symlinks = False
             else:
                 use_symlinks = True


### PR DESCRIPTION
A lot of the current issue has to do with installation. I experienced a similar problem with `curl -sSL https://install.python-poetry.org | python3 -` on M1 Mac v13.0.1. The cause of the problem is symlink and it is resolved in this PR. Recommendations were provided [here](https://github.com/python-poetry/poetry/pull/1069#issue-439430427) and [here](https://github.com/python-poetry/install.python-poetry.org/issues/24#issuecomment-1226504499).

I tested by running `python install-poetry.py` on my mac and poetry was installed successfully. I believe this should resolve #24 too.

However, I also find it surprising that `python install-poetry.py -y` in [github workflows](https://github.com/python-poetry/install.python-poetry.org/blob/main/.github/workflows/installer.yml#L63) works for macos. It should be investigated.