### PR TITLE
Upgrade deps when creating virtualenv

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -306,9 +306,7 @@ class VirtualEnvironment:
             import ensurepip  # noqa: F401
             import venv
 
-            builder = venv.EnvBuilder(
-                clear=True, with_pip=True, symlinks=False, upgrade_deps=True
-            )
+            builder = venv.EnvBuilder(clear=True, with_pip=True, symlinks=False)
             context = builder.ensure_directories(target)
 
             if (

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -306,7 +306,7 @@ class VirtualEnvironment:
             import ensurepip  # noqa: F401
             import venv
 
-            builder = venv.EnvBuilder(clear=True, with_pip=True, symlinks=False)
+            builder = venv.EnvBuilder(clear=True, with_pip=True, symlinks=False, upgrade_deps=True)
             context = builder.ensure_directories(target)
 
             if (

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -306,7 +306,9 @@ class VirtualEnvironment:
             import ensurepip  # noqa: F401
             import venv
 
-            builder = venv.EnvBuilder(clear=True, with_pip=True, symlinks=False, upgrade_deps=True)
+            builder = venv.EnvBuilder(
+                clear=True, with_pip=True, symlinks=False, upgrade_deps=True
+            )
             context = builder.ensure_directories(target)
 
             if (

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -343,6 +343,12 @@ class VirtualEnvironment:
         # we do this here to ensure that outdated system default pip does not trigger older bugs
         env.pip("install", "--disable-pip-version-check", "--upgrade", "pip")
 
+        # Similarly, ensure that we have the latest setuptools; venv.EnvBuilder has an
+        # `upgrade_deps` paramter to do this, but that parameter was added in Python 3.9.
+        # Consequently we need to take this approach as long as Python < 3.9 is officially
+        # supported.
+        env.pip("install", "--upgrade", "setuptools")
+
         return env
 
     @staticmethod


### PR DESCRIPTION
Fixes #100.

Upgrading these deps helps ensure Poetry's install virtualenv is up-to-date on security fixes.