### PR TITLE
chore: migrate to ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 88
-ignore = E501, E203, W503

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,18 +4,6 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-bugbear==22.7.1
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
@@ -23,12 +11,10 @@ repos:
       - id: end-of-file-fixer
       - id: debug-statements
       - id: pretty-format-json
-        args:
-          - --autofix
+        args: [--autofix]
       - id: check-json
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.4.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.267
     hooks:
-      - id: pyupgrade
-        args: [--py36-plus]
+      - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,29 @@
-[tool.isort]
-profile = "black"
-force_single_line = true
-atomic = true
-lines_after_imports = 2
-lines_between_types = 1
-filter_files = true
-
-
-[tool.black]
+[tool.ruff]
+fix = true
+unfixable = [
+    "ERA", # do not autoremove commented out code
+]
+target-version = "py37"
 line-length = 88
-include = '\.pyi?$'
+extend-select = [
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "ERA", # flake8-eradicate/eradicate
+    "I",   # isort
+    "N",   # pep8-naming
+    "PIE", # flake8-pie
+    "PGH", # pygrep
+    "RUF", # ruff checks
+    "SIM", # flake8-simplify
+    "TCH", # flake8-type-checking
+    "TID", # flake8-tidy-imports
+    "UP",  # pyupgrade
+]
+
+[tool.ruff.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[tool.ruff.isort]
+force-single-line = true
+lines-between-types = 1
+lines-after-imports = 2


### PR DESCRIPTION
Removes the last remaining use of `flake8` in favor of `ruff`
