### PR TITLE
Fix poetry installer with homebrew python on MacOS

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, macOS, Windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         args:
           - ""
           - "--preview"

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -314,7 +314,14 @@ class VirtualEnvironment:
             import ensurepip  # noqa: F401
             import venv
 
-            builder = venv.EnvBuilder(clear=True, with_pip=True, symlinks=False)
+            use_symlinks = False
+            if os.path.islink(sys.executable):
+                link_target = os.readlink(sys.executable)
+                # if sys.executable is a relative symlink, such as python, installed
+                # from homebrew on MacOS, it will not work once copied
+                use_symlinks = not os.path.isabs(link_target)
+
+            builder = venv.EnvBuilder(clear=True, with_pip=True, symlinks=use_symlinks)
             context = builder.ensure_directories(target)
 
             if (


### PR DESCRIPTION
The change will detect when `sys.executable` is a relative symlink and avoid copying such symlink, as it would be broken in a new location.

UPDATE: Removed python 3.7 from matrix job, since it is no longer supported by latest poetry (1.6.1 as of today).

Fixes #24, #51.