### PR TITLE
fix: Installation fails on MacOS

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -327,7 +327,7 @@ class VirtualEnvironment:
             import ensurepip  # noqa: F401
             import venv
 
-            builder = venv.EnvBuilder(clear=True, with_pip=True, symlinks=False)
+            builder = venv.EnvBuilder(clear=True, with_pip=True, symlinks=MACOS)
             context = builder.ensure_directories(target)
 
             if (


### PR DESCRIPTION
Fixes #24

### Root cause

See the linked issue #24 for the failure report and reproduction.

### Summary

See the diff. The change is minimal and localized.

### Changed files

- `install-poetry.py`

### Verification

- `pytest -q --tb=long --no-header`
- Target test passes after the fix
- Full regression suite passes

Low risk. Changes are localized and covered by tests.
