### PR TITLE
Fix poetry installation on macOS when Python from Xcode Command Line Tools

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -327,6 +327,14 @@ class VirtualEnvironment:
             import ensurepip  # noqa: F401
             import venv
 
+            if sys.platform == "darwin" and "/Library/Developer/CommandLineTools" in (sys.executable or ""):
+                # The macOS Xcode Command Line Tools Python is a stub (e.g. /usr/bin/python3 ->
+                # /Library/Developer/CommandLineTools/usr/bin/python3) whose venv bin/python
+                # carries an unresolvable `@executable_path/../Python3` loader reference, so
+                # pip (and therefore the poetry install) fails with a dyld error. Use the
+                # robust virtualenv bootstrap (--always-copy) below to create a self-contained venv.
+                raise ImportError
+
             builder = venv.EnvBuilder(clear=True, with_pip=True, symlinks=False)
             context = builder.ensure_directories(target)
 
@@ -339,7 +347,9 @@ class VirtualEnvironment:
 
             builder.create(target)
         except ImportError:
-            # fallback to using virtualenv package if venv is not available, eg: ubuntu
+            # fallback to using virtualenv package if venv is not available (eg: ubuntu)
+            # or if the base interpreter is the macOS Command Line Tools stub which
+            # produces a broken venv
             python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
             virtualenv_bootstrap_url = (
                 f"https://bootstrap.pypa.io/virtualenv/{python_version}/virtualenv.pyz"

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -327,7 +327,9 @@ class VirtualEnvironment:
             import ensurepip  # noqa: F401
             import venv
 
-            if sys.platform == "darwin" and "/Library/Developer/CommandLineTools" in (sys.executable or ""):
+            if sys.platform == "darwin" and "/Library/Developer/CommandLineTools" in (
+                sys.executable or ""
+            ):
                 # The macOS Xcode Command Line Tools Python is a stub (e.g. /usr/bin/python3 ->
                 # /Library/Developer/CommandLineTools/usr/bin/python3) whose venv bin/python
                 # carries an unresolvable `@executable_path/../Python3` loader reference, so


### PR DESCRIPTION
**Root cause**: On macOS, when Python 3.x is installed by the Xcode Command Line Tools, the base interpreter is a stub (e.g. `/usr/bin/python3` -> `/Library/Developer/CommandLineTools/usr/bin/python3`). Creating a virtual environment with the stdlib `venv` module from this stub produces a venv whose `bin/python` carries an unresolvable `@executable_path/../Python3` loader reference. As a result, pip (and therefore the poetry install) fails with a dyld error: `Library not loaded: @executable_path/../Python3`.

**Fix**: When `sys.platform == "darwin"` and the interpreter path points into `/Library/Developer/CommandLineTools`, force the installer to use the existing virtualenv zipapp bootstrap path (`--always-copy`), which creates a self-contained virtual environment that is not affected by the broken stdlib venv layout.

**Behavior**: The new branch only triggers on macOS for the Command Line Tools stub interpreter. On all other platforms and Python installations the existing `venv` code path is unchanged.