### PR TITLE
Fix installation failure when Python is from macOS Command Line Tools

### DIFF
--- a/install-poetry.py
+++ b/install-poetry.py
@@ -327,6 +327,14 @@ class VirtualEnvironment:
             import ensurepip  # noqa: F401
             import venv
 
+            if sys.platform == "darwin" and "/Library/Developer/CommandLineTools" in (sys.executable or ""):
+                # The macOS Xcode Command Line Tools Python is a stub (e.g. /usr/bin/python3 ->
+                # /Library/Developer/CommandLineTools/usr/bin/python3) whose venv bin/python
+                # carries an unresolvable `@executable_path/../Python3` loader reference, so
+                # pip (and therefore the poetry install) fails with a dyld error. Use the
+                # robust virtualenv bootstrap (--always-copy) below to create a self-contained venv.
+                raise ImportError
+
             builder = venv.EnvBuilder(clear=True, with_pip=True, symlinks=False)
             context = builder.ensure_directories(target)
 
@@ -339,7 +347,9 @@ class VirtualEnvironment:
 
             builder.create(target)
         except ImportError:
-            # fallback to using virtualenv package if venv is not available, eg: ubuntu
+            # fallback to using virtualenv package if venv is not available (eg: ubuntu)
+            # or if the base interpreter is the macOS Command Line Tools stub which
+            # produces a broken venv
             python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
             virtualenv_bootstrap_url = (
                 f"https://bootstrap.pypa.io/virtualenv/{python_version}/virtualenv.pyz"

--- a/install-poetry.py
+++ b/install-poetry.py
@@ -327,7 +327,9 @@ class VirtualEnvironment:
             import ensurepip  # noqa: F401
             import venv
 
-            if sys.platform == "darwin" and "/Library/Developer/CommandLineTools" in (sys.executable or ""):
+            if sys.platform == "darwin" and "/Library/Developer/CommandLineTools" in (
+                sys.executable or ""
+            ):
                 # The macOS Xcode Command Line Tools Python is a stub (e.g. /usr/bin/python3 ->
                 # /Library/Developer/CommandLineTools/usr/bin/python3) whose venv bin/python
                 # carries an unresolvable `@executable_path/../Python3` loader reference, so


### PR DESCRIPTION
When python3 is provided by the macOS Xcode Command Line Tools (e.g. /usr/bin/python3 -> /Library/Developer/CommandLineTools/usr/bin/python3), the cpython venv it creates carries an unresolvable @executable_path\/..\/Python3 loader reference in bin\/python, so pip fails with a dyld error and the poetry install aborts.

This change makes VirtualEnvironment.make() detect that situation (sys.platform == "darwin" and /Library/Developer/CommandLineTools in sys.executable) and route through the existing robust virtualenv.pyz bootstrap (--clear --always-copy) instead of the broken cpython venv path. The branch is additive and guarded to darwin + CommandLineTools only; the normal cpython venv path is unchanged.

A new test (tests/test_installer.py) mocks the darwin/CLT interpreter and asserts the --always-copy bootstrap is used.